### PR TITLE
Handle race on session_id messaging vs timeout

### DIFF
--- a/src/elysium_bs_serial.erl
+++ b/src/elysium_bs_serial.erl
@@ -351,14 +351,14 @@ checkin_pending(Config, Node, Sid, Pending_Queue, Is_New_Connection) ->
 exec_pending_request(Reply_Ref, Reply_Pid, Node, Sid, {bare_fun, Config, Query_Fun, Args, Consistency}) ->
     try   Reply = Query_Fun(Sid, Args, Consistency),
           Reply_Pid ! {wrr, Reply_Ref, Reply}
-    catch A:B -> error_logger:error_msg("Query execution caught ~p:~p for ~p ~p ~9999p~n",
-                                        [A,B, Reply_Pid, Args, erlang:get_stacktrace()])
+    catch A:B -> lager:error("Query execution caught ~p:~p for ~p ~p ~9999p~n",
+                             [A,B, Reply_Pid, Args, erlang:get_stacktrace()])
     after _ = checkin_connection(Config, Node, Sid, false)
     end;
 exec_pending_request(Reply_Ref, Reply_Pid, Node, Sid, {mod_fun,  Config, Mod,  Fun, Args, Consistency}) ->
     try   Reply = Mod:Fun(Sid, Args, Consistency),
           Reply_Pid ! {wrr, Reply_Ref, Reply}
-    catch A:B -> error_logger:error_msg("Query execution caught ~p:~p for ~p ~p ~9999p~n",
-                                        [A,B, Reply_Pid, Args, erlang:get_stacktrace()])
+    catch A:B -> lager:error("Query execution caught ~p:~p for ~p ~p ~9999p~n",
+                             [A,B, Reply_Pid, Args, erlang:get_stacktrace()])
     after _ = checkin_connection(Config, Node, Sid, false)
     end.


### PR DESCRIPTION
Also moved the {missing_ets_data, ...} to the initial position in both receives for consistency and readability.
